### PR TITLE
Fix a bug that prevented the usage of `client.execute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.7.1
+
+* Fix a bug that prevented the usage of `client.execute`
+* The GraphQL client is now exposed as `client.gql`
+
 0.7.0
 
 * Add CRUD operations for Dato Items (all, find, create, update, destroy)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dato-rails (0.7.0)
+    dato-rails (0.7.1)
       gqli (>= 1)
       rails (>= 4)
       turbo-rails (>= 1)

--- a/fixtures/vcr_cassettes/Dato_Client/can_execute_a_query_without_errors.yml
+++ b/fixtures/vcr_cassettes/Dato_Client/can_execute_a_query_without_errors.yml
@@ -159,4 +159,314 @@ http_interactions:
         186w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?fm=webp
         249w","sizes":"(max-width: 249px) 100vw, 249px","src":"https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?fm=png","width":249,"height":251,"aspectRatio":0.9920318725099602,"alt":null,"title":null,"bgColor":"#ca7854","base64":"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAoHBwgHBgoICAgVFQoLDh4QGhUPFxUSEB0YFx8lJBsVFiEdHyslJh0oHSEeJTUlKC0vMjI+GiI4PTcwPCsxMi8BCgsLDg0OHBAQHDsoIik7Ozs7Lzs7OzU1Ly8vLy8vLy81LzUvLy81Ly8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vL//AABEIABkAGAMBIgACEQEDEQH/xAAYAAEBAQEBAAAAAAAAAAAAAAAGAAQHA//EACMQAAEDAgYDAQAAAAAAAAAAAAEAAgMEBQYSITEycREzQRP/xAAWAQEBAQAAAAAAAAAAAAAAAAADBAL/xAAbEQADAQADAQAAAAAAAAAAAAAAAQIDERIxIf/aAAwDAQACEQMRAD8A5Ja25q5ie0jD+I6ROyUThPncNU5pYfEO3xHpLKckkCsUt8SM7UteLqc5A8Di5S1nL6h68dvhvtsADxok8DAIkft3NI4vUrHKZHNtBzEEAljcCFL3vOxUkhcIDWm69P/Z"}}}]}}}}'
   recorded_at: Tue, 14 Feb 2023 09:13:40 GMT
+- request:
+    method: post
+    uri: https://graphql.datocms.com/
+    body:
+      encoding: UTF-8
+      string: '{"query":"query {\n  homepage {\n    id\n    _createdAt\n    _seoMetaTags
+        {\n      attributes\n      content\n      tag\n    }\n    content {\n      value\n      blocks
+        {\n        id\n        image {\n          responsiveImage(imgixParams: {fm:
+        png}) {\n            srcSet\n            webpSrcSet\n            sizes\n            src\n            width\n            height\n            aspectRatio\n            alt\n            title\n            bgColor\n            base64\n          }\n        }\n      }\n    }\n  }\n}\n"}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - gqli.rb/1.2.0; http.rb/5.1.1
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - graphql.datocms.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 01 May 2023 11:31:45 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Cf-Ray:
+      - 7c07b333a81d01e3-ZRH
+      Access-Control-Allow-Origin:
+      - "*"
+      Age:
+      - '839'
+      Cache-Control:
+      - no-store
+      Etag:
+      - W/"6d6bd54cddedd102f7ad54d203989200"
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Vary:
+      - Authorization, Accept-Encoding, X-Environment, X-Include-Drafts, X-Exclude-Invalid
+      Via:
+      - 1.1 vegur, 1.1 varnish, 1.1 varnish
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - authorization, content-type, x-environment, x-organization, x-site-domain,
+        x-api-version, user-agent, x-session-id, x-include-drafts, x-exclude-invalid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, OPTIONS, DELETE
+      Access-Control-Expose-Headers:
+      - x-ratelimit-limit, x-ratelimit-remaining, x-ratelimit-reset
+      Access-Control-Max-Age:
+      - '1728000'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Analysis-Fields-Count:
+      - '2'
+      X-Analysis-Introspection:
+      - '0'
+      X-Analysis-Item-Types-Count:
+      - '2'
+      X-Analysis-Successful:
+      - '1'
+      X-Batch:
+      - '0'
+      X-Cache:
+      - HIT, HIT
+      X-Cache-Hits:
+      - 1, 1
+      X-Cacheable-On-Cdn:
+      - 'true'
+      X-Cacheable-On-Cdn-Query-Length-Limit:
+      - 401/8192
+      X-Complexity:
+      - '135'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Environment:
+      - main
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Max-Complexity:
+      - '10000000'
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Queue-Time:
+      - 0ms
+      X-Request-Id:
+      - ce22bb43-93df-4c1f-94f3-91bfb78b3908
+      X-Runtime:
+      - '0.071496'
+      X-Served-By:
+      - cache-dub4322-DUB, cache-mxp6923-MXP
+      X-Timer:
+      - S1682940706.895626,VS0,VE1
+      X-Timings-Execution:
+      - '0.018'
+      X-Timings-Preanalysis:
+      - '0.01'
+      X-Timings-Schema-Generation:
+      - '0.021'
+      X-Timings-Total:
+      - '0.049'
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - cloudflare
+    body:
+      encoding: UTF-8
+      string: '{"data":{"homepage":{"id":"56302","_createdAt":"2021-10-22T14:45:19+01:00","_seoMetaTags":[{"attributes":null,"content":"SEO
+        title","tag":"title"},{"attributes":{"property":"og:title","content":"SEO
+        title"},"content":null,"tag":"meta"},{"attributes":{"name":"twitter:title","content":"SEO
+        title"},"content":null,"tag":"meta"},{"attributes":{"name":"description","content":"SEO
+        description"},"content":null,"tag":"meta"},{"attributes":{"property":"og:description","content":"SEO
+        description"},"content":null,"tag":"meta"},{"attributes":{"name":"twitter:description","content":"SEO
+        description"},"content":null,"tag":"meta"},{"attributes":{"property":"og:image","content":"https://www.datocms-assets.com/65438/1634910050-img0429.heic?auto=format&fit=max&w=1200"},"content":null,"tag":"meta"},{"attributes":{"name":"twitter:image","content":"https://www.datocms-assets.com/65438/1634910050-img0429.heic?auto=format&fit=max&w=1200"},"content":null,"tag":"meta"},{"attributes":{"property":"og:locale","content":"en"},"content":null,"tag":"meta"},{"attributes":{"property":"og:type","content":"website"},"content":null,"tag":"meta"},{"attributes":{"property":"article:modified_time","content":"2022-03-24T13:55:14Z"},"content":null,"tag":"meta"},{"attributes":{"name":"twitter:card","content":"summary_large_image"},"content":null,"tag":"meta"}],"content":{"value":{"schema":"dast","document":{"type":"root","children":[{"type":"heading","level":1,"children":[{"type":"span","value":"Welcome
+        to "},{"type":"span","marks":["strong"],"value":"DATO-RAILS"}]},{"type":"paragraph","children":[{"type":"span","value":""}]},{"type":"paragraph","children":[{"type":"span","value":"Here
+        is a paragraph with some content to be tested"}]},{"type":"heading","level":2,"children":[{"type":"span","value":"This
+        is a smaller heading"}]},{"type":"list","style":"numbered","children":[{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"and"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"a"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"numbered"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"list"}]}]}]},{"type":"paragraph","children":[{"type":"span","value":""}]},{"type":"heading","level":2,"children":[{"type":"span","value":"This
+        is another heading"}]},{"type":"list","style":"bulleted","children":[{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"and"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"a"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"unordered"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"list"}]}]}]},{"type":"blockquote","children":[{"type":"paragraph","children":[{"type":"span","value":"Arel
+        is great only for dynamic queries"}]}],"attribution":"Alessandro Rodi"},{"type":"thematicBreak"},{"code":"client
+        = Dato::Client.new\nclient.execute!(a_query)","type":"code","language":"ruby"},{"item":"56409","type":"block"},{"type":"heading","level":6,"children":[{"type":"span","value":"One
+        last heading"}]},{"type":"paragraph","children":[{"type":"span","marks":["strong"],"value":"And
+        a longer"},{"type":"span","value":" "},{"type":"span","marks":["emphasis"],"value":"paragraph
+        with a"},{"type":"span","value":" "},{"type":"span","marks":["underline"],"value":"lot
+        of different"},{"type":"span","value":" "},{"type":"span","marks":["underline"],"value":"styles
+        all"},{"type":"span","value":" "},{"type":"span","marks":["underline","strikethrough"],"value":"together"},{"type":"span","value":".
+        "},{"type":"span","marks":["code"],"value":"We mix some"},{"type":"span","value":"
+        "},{"type":"span","marks":["highlight"],"value":"of them"},{"type":"span","value":"
+        "},{"url":"https://renuo.ch","type":"link","children":[{"type":"span","value":"to
+        see if they are all properly managed."}]}]}]}},"blocks":[{"id":"56409","image":{"responsiveImage":{"srcSet":"https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.25&fm=png
+        62w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.5&fm=png
+        124w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.75&fm=png
+        186w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?fm=png
+        249w","webpSrcSet":"https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.25&fm=webp
+        62w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.5&fm=webp
+        124w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.75&fm=webp
+        186w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?fm=webp
+        249w","sizes":"(max-width: 249px) 100vw, 249px","src":"https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?fm=png","width":249,"height":251,"aspectRatio":0.9920318725099602,"alt":null,"title":null,"bgColor":"#ca7854","base64":"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAoHBwgHBgoICAgLChQXDh0VGhcVFx0NDRUYFx4dGhYfGBUmHysvHR0oHSEiJDUlKC0vMjIyHSU4PTcwPCsxMi8BCgsLDg0OHBAQHDsoICg7NTsvNS8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vL//AABEIABkAGAMBIgACEQEDEQH/xAAZAAEAAgMAAAAAAAAAAAAAAAAGAAQBBQf/xAAjEAABBAEDBAMAAAAAAAAAAAABAAIDBBEFBhIhMUFREzIz/8QAFwEBAQEBAAAAAAAAAAAAAAAAAwIEAf/EABoRAAMAAwEAAAAAAAAAAAAAAAABAhEhMRL/2gAMAwEAAhEDEQA/AOP14flcMphQ0zlpxI9IpQike/LWkptp8skVLiWnsorIsYBGo1zXtOBHlRXNecTY6tx1UVIN9FG24KL48kBK4oqHDjgIPtj8ik0Xda6hBRTNLu2rRY3IAWFV3f8AQKKvKObZ/9k="}}}]}}}}'
+  recorded_at: Mon, 01 May 2023 11:31:45 GMT
+- request:
+    method: post
+    uri: https://graphql.datocms.com/
+    body:
+      encoding: UTF-8
+      string: '{"query":"query {\n  homepage {\n    id\n    _createdAt\n    _seoMetaTags
+        {\n      attributes\n      content\n      tag\n    }\n    content {\n      value\n      blocks
+        {\n        id\n        image {\n          responsiveImage(imgixParams: {fm:
+        png}) {\n            srcSet\n            webpSrcSet\n            sizes\n            src\n            width\n            height\n            aspectRatio\n            alt\n            title\n            bgColor\n            base64\n          }\n        }\n      }\n    }\n  }\n}\n"}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - gqli.rb/1.2.0; http.rb/5.1.1
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - graphql.datocms.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 01 May 2023 11:33:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Cf-Ray:
+      - 7c07b5769f780215-ZRH
+      Access-Control-Allow-Origin:
+      - "*"
+      Age:
+      - '931'
+      Cache-Control:
+      - no-store
+      Etag:
+      - W/"6d6bd54cddedd102f7ad54d203989200"
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Vary:
+      - Authorization, Accept-Encoding, X-Environment, X-Include-Drafts, X-Exclude-Invalid
+      Via:
+      - 1.1 vegur, 1.1 varnish, 1.1 varnish
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - authorization, content-type, x-environment, x-organization, x-site-domain,
+        x-api-version, user-agent, x-session-id, x-include-drafts, x-exclude-invalid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, OPTIONS, DELETE
+      Access-Control-Expose-Headers:
+      - x-ratelimit-limit, x-ratelimit-remaining, x-ratelimit-reset
+      Access-Control-Max-Age:
+      - '1728000'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Analysis-Fields-Count:
+      - '2'
+      X-Analysis-Introspection:
+      - '0'
+      X-Analysis-Item-Types-Count:
+      - '2'
+      X-Analysis-Successful:
+      - '1'
+      X-Batch:
+      - '0'
+      X-Cache:
+      - MISS, HIT
+      X-Cache-Hits:
+      - 0, 1
+      X-Cacheable-On-Cdn:
+      - 'true'
+      X-Cacheable-On-Cdn-Query-Length-Limit:
+      - 401/8192
+      X-Complexity:
+      - '135'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Environment:
+      - main
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Max-Complexity:
+      - '10000000'
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Queue-Time:
+      - 0ms
+      X-Request-Id:
+      - ce22bb43-93df-4c1f-94f3-91bfb78b3908
+      X-Runtime:
+      - '0.071496'
+      X-Served-By:
+      - cache-dub4322-DUB, cache-fra-eddf8230036-FRA
+      X-Timer:
+      - S1682940799.527201,VS0,VE1
+      X-Timings-Execution:
+      - '0.018'
+      X-Timings-Preanalysis:
+      - '0.01'
+      X-Timings-Schema-Generation:
+      - '0.021'
+      X-Timings-Total:
+      - '0.049'
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - cloudflare
+    body:
+      encoding: UTF-8
+      string: '{"data":{"homepage":{"id":"56302","_createdAt":"2021-10-22T14:45:19+01:00","_seoMetaTags":[{"attributes":null,"content":"SEO
+        title","tag":"title"},{"attributes":{"property":"og:title","content":"SEO
+        title"},"content":null,"tag":"meta"},{"attributes":{"name":"twitter:title","content":"SEO
+        title"},"content":null,"tag":"meta"},{"attributes":{"name":"description","content":"SEO
+        description"},"content":null,"tag":"meta"},{"attributes":{"property":"og:description","content":"SEO
+        description"},"content":null,"tag":"meta"},{"attributes":{"name":"twitter:description","content":"SEO
+        description"},"content":null,"tag":"meta"},{"attributes":{"property":"og:image","content":"https://www.datocms-assets.com/65438/1634910050-img0429.heic?auto=format&fit=max&w=1200"},"content":null,"tag":"meta"},{"attributes":{"name":"twitter:image","content":"https://www.datocms-assets.com/65438/1634910050-img0429.heic?auto=format&fit=max&w=1200"},"content":null,"tag":"meta"},{"attributes":{"property":"og:locale","content":"en"},"content":null,"tag":"meta"},{"attributes":{"property":"og:type","content":"website"},"content":null,"tag":"meta"},{"attributes":{"property":"article:modified_time","content":"2022-03-24T13:55:14Z"},"content":null,"tag":"meta"},{"attributes":{"name":"twitter:card","content":"summary_large_image"},"content":null,"tag":"meta"}],"content":{"value":{"schema":"dast","document":{"type":"root","children":[{"type":"heading","level":1,"children":[{"type":"span","value":"Welcome
+        to "},{"type":"span","marks":["strong"],"value":"DATO-RAILS"}]},{"type":"paragraph","children":[{"type":"span","value":""}]},{"type":"paragraph","children":[{"type":"span","value":"Here
+        is a paragraph with some content to be tested"}]},{"type":"heading","level":2,"children":[{"type":"span","value":"This
+        is a smaller heading"}]},{"type":"list","style":"numbered","children":[{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"and"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"a"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"numbered"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"list"}]}]}]},{"type":"paragraph","children":[{"type":"span","value":""}]},{"type":"heading","level":2,"children":[{"type":"span","value":"This
+        is another heading"}]},{"type":"list","style":"bulleted","children":[{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"and"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"a"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"unordered"}]}]},{"type":"listItem","children":[{"type":"paragraph","children":[{"type":"span","value":"list"}]}]}]},{"type":"blockquote","children":[{"type":"paragraph","children":[{"type":"span","value":"Arel
+        is great only for dynamic queries"}]}],"attribution":"Alessandro Rodi"},{"type":"thematicBreak"},{"code":"client
+        = Dato::Client.new\nclient.execute!(a_query)","type":"code","language":"ruby"},{"item":"56409","type":"block"},{"type":"heading","level":6,"children":[{"type":"span","value":"One
+        last heading"}]},{"type":"paragraph","children":[{"type":"span","marks":["strong"],"value":"And
+        a longer"},{"type":"span","value":" "},{"type":"span","marks":["emphasis"],"value":"paragraph
+        with a"},{"type":"span","value":" "},{"type":"span","marks":["underline"],"value":"lot
+        of different"},{"type":"span","value":" "},{"type":"span","marks":["underline"],"value":"styles
+        all"},{"type":"span","value":" "},{"type":"span","marks":["underline","strikethrough"],"value":"together"},{"type":"span","value":".
+        "},{"type":"span","marks":["code"],"value":"We mix some"},{"type":"span","value":"
+        "},{"type":"span","marks":["highlight"],"value":"of them"},{"type":"span","value":"
+        "},{"url":"https://renuo.ch","type":"link","children":[{"type":"span","value":"to
+        see if they are all properly managed."}]}]}]}},"blocks":[{"id":"56409","image":{"responsiveImage":{"srcSet":"https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.25&fm=png
+        62w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.5&fm=png
+        124w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.75&fm=png
+        186w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?fm=png
+        249w","webpSrcSet":"https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.25&fm=webp
+        62w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.5&fm=webp
+        124w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?dpr=0.75&fm=webp
+        186w,https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?fm=webp
+        249w","sizes":"(max-width: 249px) 100vw, 249px","src":"https://www.datocms-assets.com/65438/1648072311-alessandro-portrait.png?fm=png","width":249,"height":251,"aspectRatio":0.9920318725099602,"alt":null,"title":null,"bgColor":"#ca7854","base64":"data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAoHBwgHBgoICAgLChQXDh0VGhcVFx0NDRUYFx4dGhYfGBUmHysvHR0oHSEiJDUlKC0vMjIyHSU4PTcwPCsxMi8BCgsLDg0OHBAQHDsoICg7NTsvNS8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vL//AABEIABkAGAMBIgACEQEDEQH/xAAZAAEAAgMAAAAAAAAAAAAAAAAGAAQBBQf/xAAjEAABBAEDBAMAAAAAAAAAAAABAAIDBBEFBhIhMUFREzIz/8QAFwEBAQEBAAAAAAAAAAAAAAAAAwIEAf/EABoRAAMAAwEAAAAAAAAAAAAAAAABAhEhMRL/2gAMAwEAAhEDEQA/AOP14flcMphQ0zlpxI9IpQike/LWkptp8skVLiWnsorIsYBGo1zXtOBHlRXNecTY6tx1UVIN9FG24KL48kBK4oqHDjgIPtj8ik0Xda6hBRTNLu2rRY3IAWFV3f8AQKKvKObZ/9k="}}}]}}}}'
+  recorded_at: Mon, 01 May 2023 11:33:18 GMT
 recorded_with: VCR 6.1.0

--- a/lib/dato/client.rb
+++ b/lib/dato/client.rb
@@ -1,12 +1,11 @@
 module Dato
   class Client
-    delegate :live!, to: :@gql_client
-    delegate :execute!, to: :@gql_client
-    attr_reader :items
+    delegate :live!, :execute!, :execute, to: :@gql
+    attr_reader :items, :gql
 
     def initialize(api_token = Dato::Config.api_token, validate_query: false, preview: false, live: false)
       @api_token = api_token
-      @gql_client = Dato::Gql.new(api_token, validate_query, preview, live)
+      @gql = Dato::Gql.new(api_token, validate_query, preview, live)
       @items = Dato::Items.new(api_token)
     end
   end

--- a/lib/dato/version.rb
+++ b/lib/dato/version.rb
@@ -1,3 +1,3 @@
 module Dato
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/spec/dato/client_spec.rb
+++ b/spec/dato/client_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe Dato::Client, :vcr do
   it "can execute a query without errors" do
     response = client.execute!(homepage_query)
     expect(response.data.homepage.id).to be_present
+
+    response = client.execute(homepage_query)
+    expect(response.data.homepage.id).to be_present
+
+    response = client.gql.execute!(homepage_query)
+    expect(response.data.homepage.id).to be_present
   end
 
   context "when preview is true" do


### PR DESCRIPTION
* The GraphQL client is now exposed as `client.gql`